### PR TITLE
Require priv for ws_get_config

### DIFF
--- a/custom_components/meshtastic_ui/websocket_api.py
+++ b/custom_components/meshtastic_ui/websocket_api.py
@@ -517,6 +517,9 @@ async def ws_get_config(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Return full radio config (local_config, module_config, channels, owner, metadata)."""
+    if not connection.user.is_admin:
+        connection.send_error(msg["id"], "unauthorized", "Admin access required")
+        return
     conn = _get_connection(hass)
     try:
         config = await conn.async_get_config()


### PR DESCRIPTION
## Summary

`ws_get_config` returned radio config including channel PSK keys for any authenticated HA user.
I copied the convention found in the set config method. this guard should be consistent.

## Test plan

- [x] Log in as a non-admin HA user and confirm `meshtastic_ui/get_config` returns an unauthorized error
- [x] Log in as an admin HA user and confirm the Settings tab still loads correctly
- [x] Verify `ws_set_config` behavior is unchanged