### PR TITLE
Fix reconnect banner to actually reconnect the radio

### DIFF
--- a/custom_components/meshtastic_ui/connection.py
+++ b/custom_components/meshtastic_ui/connection.py
@@ -752,6 +752,12 @@ class MeshtasticConnection:
         """Cancel any pending backoff and attempt to reconnect immediately."""
         if self._reconnect_task is not None:
             self._reconnect_task.cancel()
+            # Wait for the task to actually finish so it can't race with us
+            # mid-`_create_interface` and stomp on `self._interface`.
+            try:
+                await self._reconnect_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
             self._reconnect_task = None
 
         if self._interface is not None:

--- a/custom_components/meshtastic_ui/connection.py
+++ b/custom_components/meshtastic_ui/connection.py
@@ -748,12 +748,32 @@ class MeshtasticConnection:
                 self._async_reconnect_loop()
             )
 
-    async def _async_reconnect_loop(self) -> None:
+    async def async_force_reconnect(self) -> None:
+        """Cancel any pending backoff and attempt to reconnect immediately."""
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            self._reconnect_task = None
+
+        if self._interface is not None:
+            old = self._interface
+            self._interface = None
+            try:
+                await self._hass.async_add_executor_job(old.close)
+            except Exception:  # noqa: BLE001
+                pass
+
+        self._set_state(ConnectionState.RECONNECTING)
+        self._reconnect_task = asyncio.ensure_future(
+            self._async_reconnect_loop(initial_delay=0)
+        )
+
+    async def _async_reconnect_loop(self, initial_delay: int = MIN_RECONNECT_DELAY) -> None:
         """Attempt to reconnect with exponential backoff."""
-        delay = MIN_RECONNECT_DELAY
+        delay = initial_delay
         while self._state == ConnectionState.RECONNECTING:
-            _LOGGER.debug("Reconnecting in %d seconds...", delay)
-            await asyncio.sleep(delay)
+            if delay > 0:
+                _LOGGER.debug("Reconnecting in %d seconds...", delay)
+                await asyncio.sleep(delay)
             if self._state != ConnectionState.RECONNECTING:
                 return
 

--- a/custom_components/meshtastic_ui/ha_frontend/panel.js
+++ b/custom_components/meshtastic_ui/ha_frontend/panel.js
@@ -916,9 +916,9 @@ class MeshtasticUiPanel extends LitElement {
         </div>
       </div>
       ${this._showReconnectBanner ? html`
-        <div class="reconnect-banner" @click=${() => location.reload()}>
+        <div class="reconnect-banner" @click=${() => this.hass.callWS({ type: "meshtastic_ui/reconnect" }).catch(() => {})}>
           <ha-icon icon="mdi:connection"></ha-icon>
-          Connection lost — click to refresh
+          Connection lost — click to reconnect
         </div>
       ` : ""}
       <div class="content">

--- a/custom_components/meshtastic_ui/ha_frontend/panel.js
+++ b/custom_components/meshtastic_ui/ha_frontend/panel.js
@@ -71,6 +71,7 @@ class MeshtasticUiPanel extends LitElement {
       _nodeDialogId: { type: String },
       _nodeDialogFeedback: { type: String },
       _showReconnectBanner: { type: Boolean },
+      _reconnecting: { type: Boolean },
     };
   }
 
@@ -101,6 +102,7 @@ class MeshtasticUiPanel extends LitElement {
     this._nodeDialogId = null;
     this._nodeDialogFeedback = "";
     this._showReconnectBanner = false;
+    this._reconnecting = false;
     this._wsFailCount = 0;
     this._timeSeries = null;
     this._packetTypes = null;
@@ -214,6 +216,23 @@ class MeshtasticUiPanel extends LitElement {
       this._wsFailCount++;
       if (this._wsFailCount >= 2) this._showReconnectBanner = true;
       return null;
+    }
+  }
+
+  async _handleReconnectClick() {
+    if (this._reconnecting) return;
+    this._reconnecting = true;
+    try {
+      // Try a backend force-reconnect first — works when the radio dropped
+      // but the HA WebSocket is still alive. Banner clears on the next
+      // successful WS call.
+      await this.hass.callWS({ type: "meshtastic_ui/reconnect" });
+    } catch (err) {
+      // HA WebSocket itself is unreachable — page reload is the only recovery.
+      location.reload();
+      return;
+    } finally {
+      this._reconnecting = false;
     }
   }
 
@@ -916,9 +935,9 @@ class MeshtasticUiPanel extends LitElement {
         </div>
       </div>
       ${this._showReconnectBanner ? html`
-        <div class="reconnect-banner" @click=${() => this.hass.callWS({ type: "meshtastic_ui/reconnect" }).catch(() => {})}>
+        <div class="reconnect-banner" @click=${() => this._handleReconnectClick()}>
           <ha-icon icon="mdi:connection"></ha-icon>
-          Connection lost — click to reconnect
+          ${this._reconnecting ? "Reconnecting…" : "Connection lost — click to reconnect"}
         </div>
       ` : ""}
       <div class="content">

--- a/custom_components/meshtastic_ui/websocket_api.py
+++ b/custom_components/meshtastic_ui/websocket_api.py
@@ -49,6 +49,7 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
     async_register_command(hass, ws_connection_status)
     async_register_command(hass, ws_subscribe_nodes)
     async_register_command(hass, ws_subscribe_delivery)
+    async_register_command(hass, ws_reconnect)
     async_register_command(hass, ws_get_config)
     async_register_command(hass, ws_set_config)
     async_register_command(hass, ws_get_channels)
@@ -505,6 +506,24 @@ async def ws_connection_status(
             "connection_type": str(conn.connection_type),
         },
     )
+
+
+@websocket_command(
+    {
+        vol.Required("type"): f"{WS_PREFIX}/reconnect",
+    }
+)
+@async_response
+async def ws_reconnect(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Force an immediate reconnect to the radio."""
+    if not connection.user.is_admin:
+        connection.send_error(msg["id"], "unauthorized", "Admin access required")
+        return
+    conn = _get_connection(hass)
+    await conn.async_force_reconnect()
+    connection.send_result(msg["id"], {"success": True})
 
 
 @websocket_command(


### PR DESCRIPTION
Replace location.reload() with a meshtastic_ui/reconnect WebSocket command. Clicking the banner now triggers an immediate backend reconnect instead of a page reload.