### PR TITLE
Reconnect button, connection watchdog, and reconnect loop fixes

### DIFF
--- a/custom_components/meshtastic_ui/connection.py
+++ b/custom_components/meshtastic_ui/connection.py
@@ -748,12 +748,32 @@ class MeshtasticConnection:
                 self._async_reconnect_loop()
             )
 
-    async def _async_reconnect_loop(self) -> None:
+    async def async_force_reconnect(self) -> None:
+        """Cancel any pending backoff and attempt to reconnect immediately."""
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            self._reconnect_task = None
+
+        if self._interface is not None:
+            old = self._interface
+            self._interface = None
+            try:
+                await self._hass.async_add_executor_job(old.close)
+            except Exception:  # noqa: BLE001
+                pass
+
+        self._set_state(ConnectionState.RECONNECTING)
+        self._reconnect_task = asyncio.ensure_future(
+            self._async_reconnect_loop(initial_delay=0)
+        )
+
+    async def _async_reconnect_loop(self, initial_delay: int = MIN_RECONNECT_DELAY) -> None:
         """Attempt to reconnect with exponential backoff."""
-        delay = MIN_RECONNECT_DELAY
+        delay = initial_delay
         while self._state == ConnectionState.RECONNECTING:
-            _LOGGER.debug("Reconnecting in %d seconds...", delay)
-            await asyncio.sleep(delay)
+            if delay > 0:
+                _LOGGER.debug("Reconnecting in %d seconds...", delay)
+                await asyncio.sleep(delay)
             if self._state != ConnectionState.RECONNECTING:
                 return
 

--- a/custom_components/meshtastic_ui/connection.py
+++ b/custom_components/meshtastic_ui/connection.py
@@ -173,6 +173,7 @@ class MeshtasticConnection:
         self._interface: Any | None = None
         self._state = ConnectionState.DISCONNECTED
         self._reconnect_task: asyncio.Task | None = None
+        self._reconnect_gen: int = 0  # incremented each time a new loop is started
         self._watchdog_task: asyncio.Task | None = None
         self._last_activity_time: float = 0.0
 
@@ -263,10 +264,11 @@ class MeshtasticConnection:
                 "Initial connection to Meshtastic radio failed (%s), will retry", err
             )
             self._interface = None
+            self._reconnect_gen += 1
             self._set_state(ConnectionState.RECONNECTING)
             if self._reconnect_task is None or self._reconnect_task.done():
                 self._reconnect_task = asyncio.ensure_future(
-                    self._async_reconnect_loop()
+                    self._async_reconnect_loop(gen=self._reconnect_gen)
                 )
 
     async def async_disconnect(self) -> None:
@@ -320,8 +322,11 @@ class MeshtasticConnection:
 
         # Bypass the DISCONNECTED guard in _async_handle_disconnected —
         # always start a fresh reconnect loop, skipping the initial backoff delay.
+        self._reconnect_gen += 1
         self._set_state(ConnectionState.RECONNECTING)
-        self._reconnect_task = asyncio.ensure_future(self._async_reconnect_loop(initial_delay=0))
+        self._reconnect_task = asyncio.ensure_future(
+            self._async_reconnect_loop(initial_delay=0, gen=self._reconnect_gen)
+        )
 
     async def async_send_text(
         self,
@@ -680,6 +685,7 @@ class MeshtasticConnection:
     def _start_watchdog(self) -> None:
         """Start the connection watchdog task."""
         self._stop_watchdog()
+        self._last_activity_time = time.monotonic()  # reset on every (re)connect
         self._watchdog_task = asyncio.ensure_future(self._async_watchdog_loop())
 
     def _stop_watchdog(self) -> None:
@@ -861,20 +867,21 @@ class MeshtasticConnection:
             return  # intentional disconnect, don't reconnect
         _LOGGER.warning("Lost connection to Meshtastic radio, will reconnect")
         self._stop_watchdog()
+        self._reconnect_gen += 1
         self._set_state(ConnectionState.RECONNECTING)
         if self._reconnect_task is None or self._reconnect_task.done():
             self._reconnect_task = asyncio.ensure_future(
-                self._async_reconnect_loop()
+                self._async_reconnect_loop(gen=self._reconnect_gen)
             )
 
-    async def _async_reconnect_loop(self, initial_delay: int = MIN_RECONNECT_DELAY) -> None:
+    async def _async_reconnect_loop(self, initial_delay: int = MIN_RECONNECT_DELAY, gen: int = 0) -> None:
         """Attempt to reconnect with exponential backoff."""
         delay = initial_delay
-        while self._state == ConnectionState.RECONNECTING:
+        while self._state == ConnectionState.RECONNECTING and gen == self._reconnect_gen:
             if delay > 0:
                 _LOGGER.debug("Reconnecting in %d seconds...", delay)
                 await asyncio.sleep(delay)
-            if self._state != ConnectionState.RECONNECTING:
+            if self._state != ConnectionState.RECONNECTING or gen != self._reconnect_gen:
                 return
 
             # Clean up old interface.
@@ -896,11 +903,12 @@ class MeshtasticConnection:
                 _LOGGER.debug("Reconnected to Meshtastic radio")
                 return
             except Exception:  # noqa: BLE001
+                next_delay = min(max(delay * 2, MIN_RECONNECT_DELAY), MAX_RECONNECT_DELAY)
                 _LOGGER.debug(
                     "Reconnect attempt failed, next try in %d seconds",
-                    min(delay * 2, MAX_RECONNECT_DELAY),
+                    next_delay,
                 )
-                delay = min(delay * 2, MAX_RECONNECT_DELAY)
+                delay = next_delay
 
     def _set_state(self, new_state: ConnectionState) -> None:
         """Update connection state and notify callbacks."""

--- a/custom_components/meshtastic_ui/connection.py
+++ b/custom_components/meshtastic_ui/connection.py
@@ -15,9 +15,9 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_RECONNECT_DELAY = 5
 MAX_RECONNECT_DELAY = 300  # 5 minutes
-
-WATCHDOG_INTERVAL = 60    # seconds between watchdog checks
-WATCHDOG_THRESHOLD = 300  # seconds of inactivity before assuming a dead connection
+WATCHDOG_INTERVAL = 60    # seconds between liveness checks
+WATCHDOG_TIMEOUT = 30     # seconds to wait for a liveness probe
+WATCHDOG_THRESHOLD = 300  # seconds of inactivity before a deeper probe
 
 
 def _apply_protobuf_values(
@@ -254,6 +254,7 @@ class MeshtasticConnection:
             )
             self._setup_pubsub_listeners()
             self._set_state(ConnectionState.CONNECTED)
+            self._start_watchdog()
             _LOGGER.debug(
                 "Connected to Meshtastic radio via %s", self._connection_type
             )
@@ -270,6 +271,7 @@ class MeshtasticConnection:
 
     async def async_disconnect(self) -> None:
         """Disconnect from the radio and stop reconnection attempts."""
+        self._stop_watchdog()
         if self._reconnect_task is not None:
             self._reconnect_task.cancel()
             self._reconnect_task = None
@@ -289,6 +291,37 @@ class MeshtasticConnection:
                 pass
 
         self._set_state(ConnectionState.DISCONNECTED)
+
+    async def async_force_reconnect(self) -> None:
+        """Force a full disconnect and reconnect regardless of current state.
+
+        Unlike the automatic reconnect loop (which only triggers on a
+        connection.lost pubsub event), this can be called at any time —
+        including when the state is stuck at CONNECTED but the radio is
+        silently unresponsive.
+        """
+        _LOGGER.info("Force reconnect requested by user")
+
+        self._stop_watchdog()
+
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            self._reconnect_task = None
+
+        self._teardown_pubsub_listeners()
+
+        if self._interface is not None:
+            old = self._interface
+            self._interface = None
+            try:
+                await self._hass.async_add_executor_job(old.close)
+            except Exception:  # noqa: BLE001
+                pass
+
+        # Bypass the DISCONNECTED guard in _async_handle_disconnected —
+        # always start a fresh reconnect loop, skipping the initial backoff delay.
+        self._set_state(ConnectionState.RECONNECTING)
+        self._reconnect_task = asyncio.ensure_future(self._async_reconnect_loop(initial_delay=0))
 
     async def async_send_text(
         self,
@@ -644,6 +677,78 @@ class MeshtasticConnection:
 
         await self._hass.async_add_executor_job(_execute)
 
+    def _start_watchdog(self) -> None:
+        """Start the connection watchdog task."""
+        self._stop_watchdog()
+        self._watchdog_task = asyncio.ensure_future(self._async_watchdog_loop())
+
+    def _stop_watchdog(self) -> None:
+        """Cancel the connection watchdog task."""
+        if self._watchdog_task is not None:
+            self._watchdog_task.cancel()
+            self._watchdog_task = None
+
+    async def _async_watchdog_loop(self) -> None:
+        """Periodically probe the radio to detect silent TCP hangs.
+
+        The meshtastic TCP interface can go silently dead — the socket stays
+        open but stops receiving data, so no connection.lost pubsub event
+        fires and the reconnect loop never starts.
+
+        Two-stage detection:
+        1. Fast check: meshtastic's internal _isConnected flag — catches clean drops.
+        2. Inactivity probe: if no packets for WATCHDOG_THRESHOLD seconds, do a
+           deeper interface probe with a WATCHDOG_TIMEOUT deadline — catches hung sockets.
+        """
+        await asyncio.sleep(WATCHDOG_INTERVAL)
+        while self._state == ConnectionState.CONNECTED:
+            # Stage 1: fast check, no I/O.
+            if not await self._hass.async_add_executor_job(self._check_alive):
+                _LOGGER.warning("Watchdog: interface reports disconnected, triggering reconnect")
+                self._hass.loop.call_soon_threadsafe(self._async_handle_disconnected)
+                return
+
+            # Stage 2: deeper probe only when traffic has been absent too long.
+            elapsed = time.monotonic() - self._last_activity_time
+            if elapsed > WATCHDOG_THRESHOLD:
+                _LOGGER.debug("Watchdog: no traffic for %.0fs, probing interface", elapsed)
+                try:
+                    alive = await asyncio.wait_for(
+                        self._hass.async_add_executor_job(self._probe_interface),
+                        timeout=WATCHDOG_TIMEOUT,
+                    )
+                    if not alive:
+                        raise RuntimeError("probe returned falsy")
+                    # Probe succeeded — reset timer so we don't probe every cycle.
+                    self._last_activity_time = time.monotonic()
+                    _LOGGER.debug("Watchdog: probe OK, radio is alive")
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.warning(
+                        "Watchdog detected dead connection (%s), triggering reconnect", err
+                    )
+                    self._hass.loop.call_soon_threadsafe(self._async_handle_disconnected)
+                    return
+            else:
+                _LOGGER.debug("Watchdog: radio is alive")
+
+            await asyncio.sleep(WATCHDOG_INTERVAL)
+
+    def _probe_interface(self) -> bool:
+        """Lightweight liveness check — runs in executor.
+
+        Returns True if the interface appears alive, raises or returns False
+        if it is dead.  Uses the node count as a proxy: a connected interface
+        always has at least our own node in the database.
+        """
+        if self._interface is None:
+            return False
+        try:
+            nodes = self._interface.nodes
+            # An empty dict is valid on a fresh connection; None means broken.
+            return nodes is not None
+        except Exception:  # noqa: BLE001
+            return False
+
     def _create_interface(self) -> Any:
         """Create a meshtastic interface (runs in executor)."""
         if self._connection_type == ConnectionType.TCP:
@@ -748,36 +853,19 @@ class MeshtasticConnection:
     def _async_handle_connected(self) -> None:
         """Handle connection established (runs on HA event loop)."""
         self._set_state(ConnectionState.CONNECTED)
+        self._start_watchdog()
 
     def _async_handle_disconnected(self) -> None:
         """Handle connection lost — start reconnect loop (runs on HA event loop)."""
         if self._state == ConnectionState.DISCONNECTED:
             return  # intentional disconnect, don't reconnect
         _LOGGER.warning("Lost connection to Meshtastic radio, will reconnect")
+        self._stop_watchdog()
         self._set_state(ConnectionState.RECONNECTING)
         if self._reconnect_task is None or self._reconnect_task.done():
             self._reconnect_task = asyncio.ensure_future(
                 self._async_reconnect_loop()
             )
-
-    async def async_force_reconnect(self) -> None:
-        """Cancel any pending backoff and attempt to reconnect immediately."""
-        if self._reconnect_task is not None:
-            self._reconnect_task.cancel()
-            self._reconnect_task = None
-
-        if self._interface is not None:
-            old = self._interface
-            self._interface = None
-            try:
-                await self._hass.async_add_executor_job(old.close)
-            except Exception:  # noqa: BLE001
-                pass
-
-        self._set_state(ConnectionState.RECONNECTING)
-        self._reconnect_task = asyncio.ensure_future(
-            self._async_reconnect_loop(initial_delay=0)
-        )
 
     async def _async_reconnect_loop(self, initial_delay: int = MIN_RECONNECT_DELAY) -> None:
         """Attempt to reconnect with exponential backoff."""
@@ -804,6 +892,7 @@ class MeshtasticConnection:
                 )
                 self._setup_pubsub_listeners()
                 self._set_state(ConnectionState.CONNECTED)
+                self._start_watchdog()
                 _LOGGER.debug("Reconnected to Meshtastic radio")
                 return
             except Exception:  # noqa: BLE001
@@ -818,47 +907,11 @@ class MeshtasticConnection:
         old_state = self._state
         self._state = new_state
         if old_state != new_state:
-            if new_state == ConnectionState.CONNECTED:
-                self._last_activity_time = time.monotonic()
-                if self._watchdog_task is None or self._watchdog_task.done():
-                    self._watchdog_task = asyncio.ensure_future(
-                        self._async_watchdog_loop()
-                    )
-            elif old_state == ConnectionState.CONNECTED:
-                if self._watchdog_task is not None:
-                    self._watchdog_task.cancel()
-                    self._watchdog_task = None
             for cb in self._connection_change_callbacks:
                 try:
                     cb(new_state, old_state)
                 except Exception:  # noqa: BLE001
                     _LOGGER.exception("Error in connection change callback")
-
-    async def _async_watchdog_loop(self) -> None:
-        """Periodically verify the radio connection is still alive."""
-        while True:
-            await asyncio.sleep(WATCHDOG_INTERVAL)
-            if self._state != ConnectionState.CONNECTED:
-                return
-
-            # Check meshtastic's internal connected flag first — fast, no I/O.
-            alive = await self._hass.async_add_executor_job(self._check_alive)
-            if not alive:
-                _LOGGER.warning(
-                    "Watchdog: radio interface reports disconnected, forcing reconnect"
-                )
-                await self.async_force_reconnect()
-                return
-
-            # Also check for prolonged inactivity — catches hung TCP sockets where
-            # the meshtastic library hasn't detected the drop yet.
-            elapsed = time.monotonic() - self._last_activity_time
-            if elapsed > WATCHDOG_THRESHOLD:
-                _LOGGER.warning(
-                    "Watchdog: no radio traffic for %.0fs, forcing reconnect", elapsed
-                )
-                await self.async_force_reconnect()
-                return
 
     def _check_alive(self) -> bool:
         """Check if the meshtastic interface is still connected (runs in executor)."""

--- a/custom_components/meshtastic_ui/connection.py
+++ b/custom_components/meshtastic_ui/connection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import enum
 import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -14,6 +15,9 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_RECONNECT_DELAY = 5
 MAX_RECONNECT_DELAY = 300  # 5 minutes
+
+WATCHDOG_INTERVAL = 60    # seconds between watchdog checks
+WATCHDOG_THRESHOLD = 300  # seconds of inactivity before assuming a dead connection
 
 
 def _apply_protobuf_values(
@@ -169,6 +173,8 @@ class MeshtasticConnection:
         self._interface: Any | None = None
         self._state = ConnectionState.DISCONNECTED
         self._reconnect_task: asyncio.Task | None = None
+        self._watchdog_task: asyncio.Task | None = None
+        self._last_activity_time: float = 0.0
 
         self._message_callbacks: list[Callable] = []
         self._node_update_callbacks: list[Callable] = []
@@ -267,6 +273,10 @@ class MeshtasticConnection:
         if self._reconnect_task is not None:
             self._reconnect_task.cancel()
             self._reconnect_task = None
+
+        if self._watchdog_task is not None:
+            self._watchdog_task.cancel()
+            self._watchdog_task = None
 
         self._teardown_pubsub_listeners()
 
@@ -676,6 +686,7 @@ class MeshtasticConnection:
         def _on_receive(packet: dict, interface: Any) -> None:
             if interface is not self._interface:
                 return
+            self._last_activity_time = time.monotonic()
             _LOGGER.debug(
                 "Received packet portnum=%s from=%s",
                 packet.get("decoded", {}).get("portnum", "?"),
@@ -702,6 +713,7 @@ class MeshtasticConnection:
         def _on_node_updated(node: dict, interface: Any = None) -> None:
             if interface is not None and interface is not self._interface:
                 return
+            self._last_activity_time = time.monotonic()
             self._hass.loop.call_soon_threadsafe(
                 self._async_dispatch_node_update, node
             )
@@ -806,8 +818,57 @@ class MeshtasticConnection:
         old_state = self._state
         self._state = new_state
         if old_state != new_state:
+            if new_state == ConnectionState.CONNECTED:
+                self._last_activity_time = time.monotonic()
+                if self._watchdog_task is None or self._watchdog_task.done():
+                    self._watchdog_task = asyncio.ensure_future(
+                        self._async_watchdog_loop()
+                    )
+            elif old_state == ConnectionState.CONNECTED:
+                if self._watchdog_task is not None:
+                    self._watchdog_task.cancel()
+                    self._watchdog_task = None
             for cb in self._connection_change_callbacks:
                 try:
                     cb(new_state, old_state)
                 except Exception:  # noqa: BLE001
                     _LOGGER.exception("Error in connection change callback")
+
+    async def _async_watchdog_loop(self) -> None:
+        """Periodically verify the radio connection is still alive."""
+        while True:
+            await asyncio.sleep(WATCHDOG_INTERVAL)
+            if self._state != ConnectionState.CONNECTED:
+                return
+
+            # Check meshtastic's internal connected flag first — fast, no I/O.
+            alive = await self._hass.async_add_executor_job(self._check_alive)
+            if not alive:
+                _LOGGER.warning(
+                    "Watchdog: radio interface reports disconnected, forcing reconnect"
+                )
+                await self.async_force_reconnect()
+                return
+
+            # Also check for prolonged inactivity — catches hung TCP sockets where
+            # the meshtastic library hasn't detected the drop yet.
+            elapsed = time.monotonic() - self._last_activity_time
+            if elapsed > WATCHDOG_THRESHOLD:
+                _LOGGER.warning(
+                    "Watchdog: no radio traffic for %.0fs, forcing reconnect", elapsed
+                )
+                await self.async_force_reconnect()
+                return
+
+    def _check_alive(self) -> bool:
+        """Check if the meshtastic interface is still connected (runs in executor)."""
+        try:
+            iface = self._interface
+            if iface is None:
+                return False
+            if hasattr(iface, "_isConnected") and not iface._isConnected:
+                return False
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+

--- a/custom_components/meshtastic_ui/ha_frontend/panel.js
+++ b/custom_components/meshtastic_ui/ha_frontend/panel.js
@@ -916,9 +916,9 @@ class MeshtasticUiPanel extends LitElement {
         </div>
       </div>
       ${this._showReconnectBanner ? html`
-        <div class="reconnect-banner" @click=${() => location.reload()}>
+        <div class="reconnect-banner" @click=${() => this.hass.callWS({ type: "meshtastic_ui/reconnect" }).catch(() => {})}>
           <ha-icon icon="mdi:connection"></ha-icon>
-          Connection lost — click to refresh
+          Connection lost — click to reconnect
         </div>
       ` : ""}
       <div class="content">

--- a/custom_components/meshtastic_ui/ha_frontend/panel.js
+++ b/custom_components/meshtastic_ui/ha_frontend/panel.js
@@ -116,7 +116,6 @@ class MeshtasticUiPanel extends LitElement {
     this._subscribing = false;
     this._subscribeGen = 0;
     this._prevConnection = null;
-    this._reconnecting = false;    
   }
 
   connectedCallback() {

--- a/custom_components/meshtastic_ui/ha_frontend/panel.js
+++ b/custom_components/meshtastic_ui/ha_frontend/panel.js
@@ -71,6 +71,8 @@ class MeshtasticUiPanel extends LitElement {
       _nodeDialogId: { type: String },
       _nodeDialogFeedback: { type: String },
       _showReconnectBanner: { type: Boolean },
+      _reconnecting: { type: Boolean },
+      _reconnectStatus: { type: String },
     };
   }
 
@@ -114,6 +116,7 @@ class MeshtasticUiPanel extends LitElement {
     this._subscribing = false;
     this._subscribeGen = 0;
     this._prevConnection = null;
+    this._reconnecting = false;    
   }
 
   connectedCallback() {
@@ -471,6 +474,17 @@ class MeshtasticUiPanel extends LitElement {
     }
   }
 
+  async _onReconnect() {
+    if (this._reconnecting) return;
+    this._reconnecting = true;
+    const result = await this._wsCommand("meshtastic_ui/reconnect");
+    // Wait briefly for the backend reconnect loop to fire before refreshing
+    setTimeout(async () => {
+      await this._loadGateways();
+      this._reconnecting = false;
+    }, 3000);
+  }
+    
   _onSelectConversation(e) {
     const conv = e.detail.conversation;
     this._selectedConversation = conv;
@@ -939,7 +953,9 @@ class MeshtasticUiPanel extends LitElement {
           .packetTypes=${this._packetTypes}
           .chartWindow=${this._chartWindow}
           .bucketInterval=${this._tsBucketInterval || 10}
+          .reconnecting=${this._reconnecting}
           @chart-window-change=${this._onChartWindowChange}
+          @reconnect=${this._onReconnect}
         ></mesh-radio-tab>`;
       case "messages":
         return html`

--- a/custom_components/meshtastic_ui/ha_frontend/views.js
+++ b/custom_components/meshtastic_ui/ha_frontend/views.js
@@ -163,6 +163,7 @@ export class MeshRadioTab extends LitElement {
       packetTypes: { type: Object },
       chartWindow: { type: Number },
       bucketInterval: { type: Number },
+      reconnecting: { type: Boolean },
     };
   }
 
@@ -173,6 +174,7 @@ export class MeshRadioTab extends LitElement {
     this.packetTypes = null;
     this.chartWindow = 3600;
     this.bucketInterval = 10;
+    this.reconnecting = false;
   }
 
   static get styles() {
@@ -214,6 +216,31 @@ export class MeshRadioTab extends LitElement {
           font-size: 13px; color: var(--secondary-text-color);
         }
         .gateway-meta span { white-space: nowrap; }
+        .reconnect-btn {
+          padding: 5px 12px;
+          border: 1px solid var(--divider-color);
+          border-radius: 8px;
+          background: var(--secondary-background-color);
+          color: var(--primary-text-color);
+          font-size: 13px;
+          font-weight: 500;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          white-space: nowrap;
+          flex-shrink: 0;
+        }
+        .reconnect-btn:hover { opacity: 0.8; }
+        .reconnect-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+        .spinner {
+          display: inline-block; width: 12px; height: 12px;
+          border: 2px solid var(--divider-color);
+          border-top-color: var(--primary-color);
+          border-radius: 50%;
+          animation: spin 0.8s linear infinite;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
         .gateway-section { padding: 16px 20px; }
         .gateway-section + .gateway-section { border-top: 1px solid var(--divider-color); }
 
@@ -356,6 +383,10 @@ export class MeshRadioTab extends LitElement {
     }));
   }
 
+  _handleReconnect() {
+    this.dispatchEvent(new CustomEvent("reconnect", { bubbles: true, composed: true }));
+  }
+
   _renderGatewayCard(gw) {
     const isConnected = gw.state?.toLowerCase() === "connected" || gw.state?.toLowerCase() === "on";
     const sensors = gw.sensors || {};
@@ -372,6 +403,16 @@ export class MeshRadioTab extends LitElement {
             ${gw.serial ? html`<span>${gw.serial}</span>` : ""}
             ${sensors.uptime ? html`<span>Up ${formatUptime(sensors.uptime)}</span>` : ""}
           </div>
+          <button
+            class="reconnect-btn"
+            ?disabled=${this.reconnecting}
+            @click=${this._handleReconnect}
+            title="Force reconnect to radio"
+          >
+            ${this.reconnecting
+              ? html`<span class="spinner"></span> Reconnecting…`
+              : html`↺ Reconnect`}
+          </button>
         </div>
 
         <div class="gateway-section">

--- a/custom_components/meshtastic_ui/websocket_api.py
+++ b/custom_components/meshtastic_ui/websocket_api.py
@@ -49,6 +49,7 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
     async_register_command(hass, ws_connection_status)
     async_register_command(hass, ws_subscribe_nodes)
     async_register_command(hass, ws_subscribe_delivery)
+    async_register_command(hass, ws_reconnect)
     async_register_command(hass, ws_get_config)
     async_register_command(hass, ws_set_config)
     async_register_command(hass, ws_get_channels)
@@ -505,6 +506,24 @@ async def ws_connection_status(
             "connection_type": str(conn.connection_type),
         },
     )
+
+
+@websocket_command(
+    {
+        vol.Required("type"): f"{WS_PREFIX}/reconnect",
+    }
+)
+@async_response
+async def ws_reconnect(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Force an immediate reconnect to the radio."""
+    if not connection.user.is_admin:
+        connection.send_error(msg["id"], "unauthorized", "Admin access required")
+        return
+    conn = _get_connection(hass)
+    await conn.async_force_reconnect()
+    connection.send_result(msg["id"], {"success": True})
 
 
 @websocket_command(

--- a/custom_components/meshtastic_ui/websocket_api.py
+++ b/custom_components/meshtastic_ui/websocket_api.py
@@ -510,24 +510,6 @@ async def ws_connection_status(
 
 @websocket_command(
     {
-        vol.Required("type"): f"{WS_PREFIX}/reconnect",
-    }
-)
-@async_response
-async def ws_reconnect(
-    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
-) -> None:
-    """Force an immediate reconnect to the radio."""
-    if not connection.user.is_admin:
-        connection.send_error(msg["id"], "unauthorized", "Admin access required")
-        return
-    conn = _get_connection(hass)
-    await conn.async_force_reconnect()
-    connection.send_result(msg["id"], {"success": True})
-
-
-@websocket_command(
-    {
         vol.Required("type"): f"{WS_PREFIX}/get_config",
     }
 )
@@ -922,6 +904,30 @@ def _downsample(values: list[float], factor: int, is_counter: bool) -> list[floa
             out.append(sum(chunk) / len(chunk))
     return out
 
+@websocket_command(
+    {
+        vol.Required("type"): f"{WS_PREFIX}/reconnect",
+    }
+)
+@async_response
+async def ws_reconnect(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Force a reconnect to the radio regardless of current state.
+
+    Useful when the connection appears stuck (state shows 'connected' but
+    the radio is unresponsive) without requiring a full HA restart.
+    """
+    if not connection.user.is_admin:
+        connection.send_error(msg["id"], "unauthorized", "Admin access required")
+        return
+    conn = _get_connection(hass)
+    try:
+        await conn.async_force_reconnect()
+        connection.send_result(msg["id"], {"success": True})
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception("Force reconnect failed")
+        connection.send_error(msg["id"], "reconnect_failed", "Operation failed")
 
 @websocket_command(
     {

--- a/custom_components/meshtastic_ui/websocket_api.py
+++ b/custom_components/meshtastic_ui/websocket_api.py
@@ -510,24 +510,6 @@ async def ws_connection_status(
 
 @websocket_command(
     {
-        vol.Required("type"): f"{WS_PREFIX}/reconnect",
-    }
-)
-@async_response
-async def ws_reconnect(
-    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
-) -> None:
-    """Force an immediate reconnect to the radio."""
-    if not connection.user.is_admin:
-        connection.send_error(msg["id"], "unauthorized", "Admin access required")
-        return
-    conn = _get_connection(hass)
-    await conn.async_force_reconnect()
-    connection.send_result(msg["id"], {"success": True})
-
-
-@websocket_command(
-    {
         vol.Required("type"): f"{WS_PREFIX}/get_config",
     }
 )


### PR DESCRIPTION
## Summary

- **Reconnect button** in the Radio tab gateway card — triggers an immediate backend reconnect with a spinner while in progress
- **Connection watchdog** — periodically checks if the radio connection is alive; detects both clean drops (via `_isConnected` flag) and silent TCP hangs (via inactivity threshold + timed probe), then triggers automatic reconnect
- **Reconnect banner** — clicking the banner now calls the backend reconnect command instead of reloading the page
- **Reconnect loop fixes** — two bugs fixed:
  - Phantom reconnect loops could survive a successful reconnect and run in parallel, interfering with each other; a generation counter ensures stale loops self-terminate immediately
  - `initial_delay=0` caused an infinite tight loop (`0*2=0`); backoff now floors at `MIN_RECONNECT_DELAY` after the first immediate attempt

## Test plan

- [ ] Verify radio connects on HA startup
- [ ] Verify Reconnect button in Radio tab triggers reconnect and spinner clears after reconnect
- [ ] Verify watchdog logs "radio is alive" every 60s when connected
- [ ] Simulate TCP drop (disable radio network) and verify auto-reconnect triggers within ~5 min
- [ ] Press Reconnect button multiple times rapidly — verify only one loop runs (check logs for single reconnect attempt sequence)