### PR TITLE
Add integration discovery for meshtastic TCP proxy

### DIFF
--- a/custom_components/meshtastic_ui/__init__.py
+++ b/custom_components/meshtastic_ui/__init__.py
@@ -8,7 +8,7 @@ from collections import deque
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -60,7 +60,48 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     # Backwards-compat: older code paths read hass.data[DOMAIN]["entries"].
     if "entries" not in hass.data[DOMAIN]:
         hass.data[DOMAIN]["entries"] = {}
+
+    # Start an integration-discovery flow for every meshtastic TCP proxy
+    # that is already configured and enabled.
+    await _async_trigger_proxy_discovery(hass)
     return True
+
+
+async def _async_trigger_proxy_discovery(hass: HomeAssistant) -> None:
+    """Fire an integration-discovery config flow for each active meshtastic TCP proxy."""
+    for entry in hass.config_entries.async_entries("meshtastic"):
+        proxy = entry.options.get("tcp_proxy", {})
+        if not proxy.get("enable"):
+            continue
+
+        port = proxy.get("port", 4403)
+        unique_id = f"proxy:{entry.entry_id}"
+
+        # Skip if a meshtastic_ui entry is already using this proxy.
+        if any(e.unique_id == unique_id for e in hass.config_entries.async_entries(DOMAIN)):
+            continue
+
+        # Skip if a discovery flow for this proxy is already in progress.
+        if any(
+            flow["context"].get("proxy_entry_id") == entry.entry_id
+            for flow in hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        ):
+            continue
+
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={
+                    "source": SOURCE_INTEGRATION_DISCOVERY,
+                    "proxy_entry_id": entry.entry_id,
+                },
+                data={
+                    "entry_id": entry.entry_id,
+                    "title": entry.title,
+                    "port": port,
+                },
+            )
+        )
 
 
 def _get_entry_data(

--- a/custom_components/meshtastic_ui/config_flow.py
+++ b/custom_components/meshtastic_ui/config_flow.py
@@ -33,6 +33,9 @@ class MeshtasticUiConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_name: str | None = None
         self._discovered_host: str | None = None
         self._discovered_port: int | None = None
+        self._proxy_entry_id: str | None = None
+        self._proxy_title: str | None = None
+        self._proxy_port: int | None = None
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Step 1: Choose connection type."""
@@ -112,6 +115,46 @@ class MeshtasticUiConfigFlow(ConfigFlow, domain=DOMAIN):
                 "port": str(self._discovered_port),
             },
             errors=errors,
+        )
+
+    async def async_step_integration_discovery(
+        self, discovery_info: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle discovery of a meshtastic integration TCP proxy."""
+        self._proxy_entry_id = discovery_info["entry_id"]
+        self._proxy_title = discovery_info["title"]
+        self._proxy_port = discovery_info["port"]
+
+        await self.async_set_unique_id(f"proxy:{self._proxy_entry_id}")
+        self._abort_if_unique_id_configured()
+
+        self.context["title_placeholders"] = {
+            "name": self._proxy_title,
+            "address": f"127.0.0.1:{self._proxy_port}",
+        }
+
+        return await self.async_step_integration_discovery_confirm()
+
+    async def async_step_integration_discovery_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm setting up via the meshtastic integration proxy."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=f"Meshtastic ({self._proxy_title} proxy)",
+                data={
+                    CONF_CONNECTION_TYPE: "tcp",
+                    CONF_TCP_HOSTNAME: "127.0.0.1",
+                    CONF_TCP_PORT: self._proxy_port,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="integration_discovery_confirm",
+            description_placeholders={
+                "name": self._proxy_title,
+                "port": str(self._proxy_port),
+            },
         )
 
     async def async_step_tcp(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:

--- a/custom_components/meshtastic_ui/strings.json
+++ b/custom_components/meshtastic_ui/strings.json
@@ -27,13 +27,18 @@
       "zeroconf_confirm": {
         "title": "Set up Meshtastic radio",
         "description": "A Meshtastic radio was discovered on the network:\n\n**{name}**\n`{host}:{port}`\n\nDo you want to set it up?"
+      },
+      "integration_discovery_confirm": {
+        "title": "Set up Meshtastic UI",
+        "description": "The Meshtastic integration (**{name}**) is running a TCP proxy on port **{port}**.\n\nConnect Meshtastic UI through it?"
       }
     },
     "error": {
       "cannot_connect": "Unable to connect to the radio. Check the address and ensure the radio is powered on."
     },
     "abort": {
-      "already_configured": "Meshtastic UI is already configured."
+      "already_configured": "Meshtastic UI is already configured.",
+      "meshtastic_not_found": "The selected Meshtastic integration could not be found."
     }
   }
 }

--- a/custom_components/meshtastic_ui/translations/en.json
+++ b/custom_components/meshtastic_ui/translations/en.json
@@ -27,13 +27,18 @@
       "zeroconf_confirm": {
         "title": "Set up Meshtastic radio",
         "description": "A Meshtastic radio was discovered on the network:\n\n**{name}**\n`{host}:{port}`\n\nDo you want to set it up?"
+      },
+      "integration_discovery_confirm": {
+        "title": "Set up Meshtastic UI",
+        "description": "The Meshtastic integration (**{name}**) is running a TCP proxy on port **{port}**.\n\nConnect Meshtastic UI through it?"
       }
     },
     "error": {
       "cannot_connect": "Unable to connect to the radio. Check the address and ensure the radio is powered on."
     },
     "abort": {
-      "already_configured": "Meshtastic UI is already configured."
+      "already_configured": "Meshtastic UI is already configured.",
+      "meshtastic_not_found": "The selected Meshtastic integration could not be found."
     }
   }
 }


### PR DESCRIPTION
## Summary

- When the `meshtastic` integration is running with its TCP proxy enabled, `meshtastic_ui` now automatically shows a discovery card in HA's integrations page
- Accepting the card configures `meshtastic_ui` to connect through the local proxy (`127.0.0.1`) rather than directly to the radio
- The existing zeroconf discovery flow is unchanged