### PR TITLE
Add View on Map jump from node dialogs

### DIFF
--- a/custom_components/meshtastic_ui/ha_frontend/panel.js
+++ b/custom_components/meshtastic_ui/ha_frontend/panel.js
@@ -70,6 +70,7 @@ class MeshtasticUiPanel extends LitElement {
       _showNotificationModal: { type: Boolean },
       _nodeDialogId: { type: String },
       _nodeDialogFeedback: { type: String },
+      _mapFocusNode: { type: Object },
       _showReconnectBanner: { type: Boolean },
       _reconnecting: { type: Boolean },
       _radios: { type: Array },
@@ -104,6 +105,7 @@ class MeshtasticUiPanel extends LitElement {
     this._showNotificationModal = false;
     this._nodeDialogId = null;
     this._nodeDialogFeedback = "";
+    this._mapFocusNode = null;
     this._showReconnectBanner = false;
     this._reconnecting = false;
     this._radios = [];
@@ -656,6 +658,12 @@ class MeshtasticUiPanel extends LitElement {
       this._nodeDialogId = nodeId;
       this._nodeDialogFeedback = "";
       return;
+    } else if (action === "view-on-map") {
+      this._mapFocusNode = { id: nodeId, ts: Date.now() };
+      this._nodeDialogId = null;
+      if (nodesTab) nodesTab.closeDialog();
+      this._setTab("map");
+      return;
     } else if (action === "send-message") {
       if (!this._dms.includes(nodeId)) {
         this._dms = [...this._dms, nodeId];
@@ -1134,7 +1142,7 @@ class MeshtasticUiPanel extends LitElement {
           ></mesh-nodes-tab>
         `;
       case "map":
-        return html`<mesh-map-tab .nodes=${this._nodes} .waypoints=${this._waypoints} .traceroutes=${this._traceroutes} .localNodeId=${this._localNodeId} @node-action=${this._onNodeAction} @waypoint-create=${this._onWaypointCreate}></mesh-map-tab>`;
+        return html`<mesh-map-tab .nodes=${this._nodes} .waypoints=${this._waypoints} .traceroutes=${this._traceroutes} .localNodeId=${this._localNodeId} .focusNode=${this._mapFocusNode} @node-action=${this._onNodeAction} @waypoint-create=${this._onWaypointCreate}></mesh-map-tab>`;
       case "settings":
         return html`
           <mesh-settings-tab
@@ -1204,7 +1212,7 @@ class MeshtasticUiPanel extends LitElement {
     const onAction = (action) => {
       if (action === "remove" && !confirm(`Remove node ${node.name || nodeId}?`)) return;
       this._onNodeAction({ detail: { action, nodeId } });
-      if (action === "send-message" || action === "remove") return; // dialog closed by handler
+      if (action === "send-message" || action === "remove" || action === "view-on-map") return; // dialog closed by handler
       if (["favorite", "unfavorite", "ignore", "unignore"].includes(action)) {
         this._showNodeDialogFeedback(action === "favorite" ? "Added to favorites" : action === "unfavorite" ? "Removed from favorites" : action === "ignore" ? "Node ignored" : "Node unignored");
       }
@@ -1289,6 +1297,11 @@ class MeshtasticUiPanel extends LitElement {
                 ? html`<span class="spinner"></span> Requesting...`
                 : html`<ha-icon icon="mdi:crosshairs-gps" style="--mdc-icon-size:16px;"></ha-icon> Request Position`}
             </button>
+            ${node.latitude != null && node.longitude != null ? html`
+            <button class="nd-btn" @click=${() => onAction("view-on-map")}>
+              <ha-icon icon="mdi:map-marker" style="--mdc-icon-size:16px;"></ha-icon> View on Map
+            </button>
+            ` : ""}
             ${!node.name ? html`
             <button class="nd-btn"
               ?disabled=${this._pendingNodeinfo === nodeId}

--- a/custom_components/meshtastic_ui/ha_frontend/views.js
+++ b/custom_components/meshtastic_ui/ha_frontend/views.js
@@ -1782,6 +1782,11 @@ export class MeshNodesTab extends LitElement {
                 ? html`<span class="spinner"></span> Requesting...`
                 : html`<ha-icon icon="mdi:crosshairs-gps" style="--mdc-icon-size: 16px;"></ha-icon> Request Position`}
             </button>
+            ${node.latitude != null && node.longitude != null ? html`
+            <button class="action-btn secondary" @click=${() => this._fireNodeAction("view-on-map", nodeId)}>
+              <ha-icon icon="mdi:map-marker" style="--mdc-icon-size: 16px;"></ha-icon> View on Map
+            </button>
+            ` : ""}
             ${!node.name ? html`
             <button class="action-btn secondary"
               ?disabled=${this.pendingNodeinfo === nodeId}
@@ -1848,6 +1853,7 @@ export class MeshMapTab extends LitElement {
       waypoints: { type: Object },
       traceroutes: { type: Object },
       localNodeId: { type: String },
+      focusNode: { type: Object },
       _waypointDialog: { type: Object },
       _addingWaypoint: { type: Boolean },
     };
@@ -1859,6 +1865,9 @@ export class MeshMapTab extends LitElement {
     this.waypoints = {};
     this.traceroutes = {};
     this.localNodeId = "";
+    this.focusNode = null;
+    this._focusedNodeSeq = null;
+    this._nodeMarkers = {};
     this._leafletLoaded = false;
     this._leafletError = false;
     this._mapInstance = null;
@@ -2108,6 +2117,9 @@ export class MeshMapTab extends LitElement {
     if (changedProps.has("traceroutes")) {
       this._updateTracerouteLayer();
       this._updateSnrLines();
+    }
+    if (changedProps.has("focusNode") && this.focusNode?.id && this._focusedNodeSeq !== this.focusNode.ts) {
+      this._focusOnNode(this.focusNode.id);
     }
   }
 
@@ -2509,6 +2521,7 @@ export class MeshMapTab extends LitElement {
   _updateNodeLayer() {
     if (!this._nodeLayer) return;
     this._nodeLayer.clearLayers();
+    this._nodeMarkers = {};
     const bounds = [];
 
     for (const [nodeId, node] of Object.entries(this.nodes)) {
@@ -2531,6 +2544,7 @@ export class MeshMapTab extends LitElement {
       marker.on("click", () => this._fireNodeAction("view-node", nodeId));
       marker.bindTooltip(name, { permanent: false, direction: "top", offset: [0, -8] });
       this._nodeLayer.addLayer(marker);
+      this._nodeMarkers[nodeId] = marker;
       bounds.push([lat, lon]);
     }
 
@@ -2541,6 +2555,25 @@ export class MeshMapTab extends LitElement {
         this._mapInstance.fitBounds(bounds, { padding: [30, 30], maxZoom: 14 });
       }
     }
+
+    // Re-apply a pending focus request now that markers exist again
+    // (node data reloads/rebuilds this layer from scratch on every update).
+    if (this.focusNode?.id && this._focusedNodeSeq !== this.focusNode.ts) {
+      this._focusOnNode(this.focusNode.id);
+    }
+  }
+
+  _focusOnNode(nodeId) {
+    if (!this._mapInstance) return;
+    const node = this.nodes[nodeId];
+    if (!node) return;
+    const lat = parseFloat(node.latitude);
+    const lon = parseFloat(node.longitude);
+    if (isNaN(lat) || isNaN(lon) || (lat === 0 && lon === 0)) return;
+    this._focusedNodeSeq = this.focusNode?.ts;
+    this._mapInstance.flyTo([lat, lon], Math.max(this._mapInstance.getZoom(), 15));
+    const marker = this._nodeMarkers[nodeId];
+    if (marker) marker.openTooltip();
   }
 
   _updateWaypointLayer() {


### PR DESCRIPTION
## Summary

- Clicking a marker on the Map tab already opens that node's info dialog, but there was no way to go the other direction — from the Nodes list to the map.
- Adds a **View on Map** button to the node detail dialog (shown only when the node has a known position), which switches to the Map tab and flies the view to that node's marker, opening its tooltip.
- Present in both node-dialog code paths (the Nodes-tab dialog and the map-marker-click dialog in the panel shell) for consistency.

## Test plan

- [ ] Open Nodes tab, click a node with a known position, click "View on Map" — verify it switches to the Map tab and flies/zooms to that node's marker with its tooltip open
- [ ] Open a node with no position known — verify no "View on Map" button appears
- [ ] Click a marker on the Map tab to open its dialog, click "View on Map" — verify it re-centers/zooms on the same node without error
- [ ] Verify normal map interaction (pan/zoom/layer toggles) still works after a jump

## Note

Reopening #64, which was closed in error on 2026-09-01 — I'd mistakenly closed it believing this had already landed on upstream `main`; it had actually only landed on my own fork's `main`. This PR carries the identical commit (`9478d83`).